### PR TITLE
Proxy API like create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ For more information, please read the document at: [http://rekit.js.org/docs/plu
  * Use [istanbul](https://github.com/gotwarlost/istanbul) for testing coverage report.
  * Use [eslint-config-airbnb](https://github.com/airbnb/javascript) for code style check.
  * Support [Redux dev tools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd).
+* Proxy to API in DEV like [create-react-app](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#proxying-api-requests-in-development). e.g.  fetch(/api/\<your path>) 
+
 
 ## Documentation
 [http://rekit.js.org](http://rekit.js.org)

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
   },
   "dependencies": {
     "argparse": "^1.0.7",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "request": "^2.81.0"    
   },
   "devDependencies": {
     "axios": "^0.16.2",
@@ -151,7 +152,6 @@
     "redux-thunk": "^2.2.0",
     "rekit-core": "^2.0.1",
     "rekit-portal": "^2.0.5",
-    "request": "^2.83.0",
     "reselect": "^3.0.1",
     "sass-loader": "^6.0.6",
     "shelljs": "^0.7.8",

--- a/package.json
+++ b/package.json
@@ -86,8 +86,7 @@
   },
   "dependencies": {
     "argparse": "^1.0.7",
-    "lodash": "^4.17.4",
-    "request": "^2.81.0"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "axios": "^0.16.2",
@@ -152,6 +151,7 @@
     "redux-thunk": "^2.2.0",
     "rekit-core": "^2.0.1",
     "rekit-portal": "^2.0.5",
+    "request": "^2.83.0",
     "reselect": "^3.0.1",
     "sass-loader": "^6.0.6",
     "shelljs": "^0.7.8",


### PR DESCRIPTION
I was hard coding the my api server directly in my react code so I was missing this feature that create-react-app offers is to proxy all /api calls to server set in your package.json. 

I put it now in the rekit object.

`
"rekit": {
   ...
   "proxy": "http:/localhost:3000", 
}
`

