### PR TITLE
Update route.js

### DIFF
--- a/packages/rekit-core/templates/route.js
+++ b/packages/rekit-core/templates/route.js
@@ -5,7 +5,7 @@ import {
 } from './';
 
 export default {
-  path: '${_.kebabCase(feature)}',
+  path: '/${_.kebabCase(feature)}',
   name: '${_.upperFirst(_.lowerCase(feature))}',
   childRoutes: [
   ],


### PR DESCRIPTION
By default, the created feature cannot be accessed due to a missing `/` prefix from the feature's default path.
What I mean here is, that when I create a new feature with `rekit add feature some-feature`, the created route with the default view will not work without adding a `/` prefix, as it's treated as relative instead of absolute..