### PR TITLE
Fixed incorrect no-underscore-dangle rule name in eslint config files

### DIFF
--- a/packages/rekit-portal/.eslintrc
+++ b/packages/rekit-portal/.eslintrc
@@ -23,7 +23,7 @@
     "function-paren-newline": 0,
     "max-len": 0,
     "no-nested-ternary": 0,
-    "no_underscore_dangle": 0,
+    "no-underscore-dangle": 0,
     "no-param-reassign": 0,
     "no-mixed-operators": 0,
     "no-console": 0,

--- a/packages/rekit-studio/.eslintrc
+++ b/packages/rekit-studio/.eslintrc
@@ -26,7 +26,7 @@
     "max-len": 0,
     "arrow-parens": 0,
     "no-nested-ternary": 0,
-    "no_underscore_dangle": 0,
+    "no-underscore-dangle": 0,
     "no-param-reassign": 0,
     "no-mixed-operators": 0,
     "no-console": 0,

--- a/packages/rekit/.eslintrc
+++ b/packages/rekit/.eslintrc
@@ -6,7 +6,7 @@
     "guard-for-in": 0,
     "max-len": 0,
     "no-nested-ternary": 0,
-    "no_underscore_dangle": 0,
+    "no-underscore-dangle": 0,
     "no-console": 0,
     "no-shadow": 0,
     "object-curly-newline": 0,


### PR DESCRIPTION
Fixed the eslint config files so underscore dangling is properly disabled by default